### PR TITLE
Update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu24.04, ubuntu22.04, ubuntu20.04, fedora39, archlinux]
-    runs-on: macos-13
+        os: [ubuntu24.04, ubuntu24.04-aarch64, ubuntu22.04, ubuntu22.04-aarch64, ubuntu20.04, ubuntu20.04-aarch64, fedora39, archlinux]
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Build Release
       id: build_release
       run: |
-        # pin at Swift v5.8.1 as > versions have ABI issues ....
-        DEVELOPER_DIR=/Applications/Xcode_14.3.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
+        DEVELOPER_DIR=/Applications/Xcode_16.1.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
 
     - name: Attach Build To Release
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubi9-aarch64, ubi9,]
+        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubi9-aarch64, ubi9, arch-aarch64, arch]
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu24.04, ubuntu24.04-aarch64, ubuntu22.04, ubuntu22.04-aarch64, ubuntu20.04, ubuntu20.04-aarch64, fedora39, archlinux]
-    runs-on: macos-14
+        os: [ubuntu24.04, ubuntu24.04-aarch64, ubuntu22.04, ubuntu22.04-aarch64, ubuntu20.04, ubuntu20.04-aarch64, fedora39, fedora39-aarch64, archlinux, archlinux-aarch64]
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - name: Build Release
       id: build_release
       run: |
-        DEVELOPER_DIR=/Applications/Xcode_16.1.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
+        DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
 
     - name: Attach Build To Release
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubi9-aarch64, ubi9, arch-aarch64, arch]
+        os: [ubuntu24.04, ubuntu22.04, ubuntu20.04, fedora39, archlinux]
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
     - name: Build Release
       id: build_release
       run: |
-        DEVELOPER_DIR=/Applications/Xcode_15.1.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
+        # pin at Swift v5.8.1 as > versions have ABI issues ....
+        DEVELOPER_DIR=/Applications/Xcode_14.3.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
 
     - name: Attach Build To Release
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubi9]
+        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubi9-aarch64, ubi9,]
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       release_tag: ${{ steps.create_release.outputs.release_tag }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Create Release
       id: create_release
       run: |
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubuntu18.04]
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build Release
       id: build_release
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     needs: create_release
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubuntu18.04]
     runs-on: macos-13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubuntu18.04]
+        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04]
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04]
+        os: [ubuntu22.04-aarch64, ubuntu22.04, ubuntu20.04-aarch64, ubuntu20.04, ubi9]
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build Release
       id: build_release
       run: |
-        DEVELOPER_DIR=/Applications/Xcode_14.3.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
+        DEVELOPER_DIR=/Applications/Xcode_15.1.app/Contents/Developer ./create-toolchain ${{ matrix.os }}
 
     - name: Attach Build To Release
       run: |

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2023 Kabir Oberai
+Copyright (c) 2018-2025 Kabir Oberai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2022 Kabir Oberai
+Copyright (c) 2018-2023 Kabir Oberai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -31,5 +31,7 @@ The currently supported versions are:
 - `ubuntu22.04-aarch64`
 - `ubi9`
 - `ubi9-aarch64`
+- `arch`
+- `arch-aarch64`
 
 Upon completion of the script, the output can be found in the `packages` directory.

--- a/README.md
+++ b/README.md
@@ -26,12 +26,9 @@ The `linux version` argument is in the format `<distribution><version>` (all low
 
 The currently supported versions are:
 - `ubuntu20.04`
-- `ubuntu20.04-aarch64`
 - `ubuntu22.04`
-- `ubuntu22.04-aarch64`
-- `ubi9`
-- `ubi9-aarch64`
-- `arch`
-- `arch-aarch64`
+- `ubuntu24.04`
+- `fedora39`
+- `archlinux`
 
 Upon completion of the script, the output can be found in the `packages` directory.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Run `./create-toolchain <linux version> <path to xctoolchain>`
 The `linux version` argument is in the format `<distribution><version>` (all lowercase). See <https://swift.org/download/> for the list of supported Linux versions.
 
 The currently supported versions are:
-- `ubuntu18.04`
 - `ubuntu20.04`
 - `ubuntu22.04`
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The `linux version` argument is in the format `<distribution><version>` (all low
 
 The currently supported versions are:
 - `ubuntu20.04`
+- `ubuntu20.04-aarch64`
 - `ubuntu22.04`
+- `ubuntu22.04-aarch64`
+- `ubi9`
 
 Upon completion of the script, the output can be found in the `packages` directory.

--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ The currently supported versions are:
 - `ubuntu22.04`
 - `ubuntu22.04-aarch64`
 - `ubi9`
+- `ubi9-aarch64`
 
 Upon completion of the script, the output can be found in the `packages` directory.

--- a/create-toolchain
+++ b/create-toolchain
@@ -112,9 +112,7 @@ cp -a "${mac_toolchain}"/usr/include linux/iphone/include
 rm linux/iphone/lib/swift/clang
 cp -a linux/{host,iphone}/lib/swift/clang
 # remove borked plutil in favor of plistutil
-rm linux/iphone/bin/plutil
-# remove c++ headers as included in SDK [TBD]
-# rm -rf linux/iphone/include/c++/
+rm linux/host/bin/plutil
 
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C

--- a/create-toolchain
+++ b/create-toolchain
@@ -112,7 +112,7 @@ cp -a "${mac_toolchain}"/usr/include linux/iphone/include
 rm linux/iphone/lib/swift/clang
 cp -a linux/{host,iphone}/lib/swift/clang
 # remove borked plutil in favor of plistutil
-rm linux/host/bin/plutil
+rm -v linux/{host,iphone}/bin/plutil
 
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C

--- a/create-toolchain
+++ b/create-toolchain
@@ -13,7 +13,7 @@ if [[ "${is_mac}" = true ]]; then
 	fi
 else
 	if [[ $# -ne 2 ]]; then
-		echo "Usage: $0 <linux version (e.g., ubuntu20.04)> [swift version (e.g., 5.8.1)]"
+		echo "Usage: $0 <linux version (e.g., ubuntu20.04)> <swift version (e.g., 6.0.3)>"
 		exit 1
 	fi
 fi

--- a/create-toolchain
+++ b/create-toolchain
@@ -6,13 +6,16 @@ DARWIN_TOOLS_VERSION="2.2.1"
 
 [[ "$(uname -s)" = "Darwin" ]] && is_mac=true
 
-if [[ $# -ne 1 && $# -ne 2 ]]; then
-	if [[ "${is_mac}" = true ]]; then
-		echo "Usage: $0 <linux version such as ubuntu20.04> [path to xctoolchain]"
-	else
-		echo "Usage: $0 <swift version> [linux version such as ubuntu20.04]"
+if [[ "${is_mac}" = true ]]; then
+	if [[ $# -ne 1 && $# -ne 2 ]]; then
+		echo "Usage: $0 <linux version (e.g., ubuntu20.04)> [(optional) path to xctoolchain]"
+		exit 1
 	fi
-	exit 1
+else
+	if [[ $# -ne 2 ]]; then
+		echo "Usage: $0 <linux version (e.g., ubuntu20.04)> [swift version (e.g., 5.8.1)]"
+		exit 1
+	fi
 fi
 
 info() { echo "[info] $1"; }
@@ -21,10 +24,9 @@ err() {
 	exit 1
 }
 
-supported_plats=("ubuntu20.04" "ubuntu20.04-aarch64" "ubuntu22.04" "ubuntu22.04-aarch64" "ubi9" "ubi9-aarch64")
-if ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "${1}" > /dev/null && \
-   ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "${2}" > /dev/null; then
-   	err "${1} ${2} is not a valid configuration"
+supported_plats=("ubuntu20.04" "ubuntu20.04-aarch64" "ubuntu22.04" "ubuntu22.04-aarch64" "ubi9" "ubi9-aarch64" "arch" "arch-aarch64")
+if ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "$1" > /dev/null; then
+   	err "$1 is not a valid configuration"
 fi
 
 mkdir -p toolchains
@@ -44,17 +46,8 @@ if [[ "${is_mac}" = true ]]; then
 	info "Detected Swift version ${swift_version}"
 	cd toolchains
 else
-	swift_version="$1"
-	linux_version="$2"
-	if [[ -z "${linux_version}" ]]; then
-		if [[ -f /etc/os-release ]]; then
-			. /etc/os-release
-			linux_version="${ID}${VERSION_ID}"
-			info "Detected Linux version ${linux_version}"
-		else
-			err "Could not auto-detect Linux version; please pass it as the second argument to '$0'."
-		fi
-	fi
+	linux_version="$1"
+	swift_version="$2"
 	file_name_mac="swift-${swift_version}-RELEASE-osx"
 	package_mac="${file_name_mac}-package.pkg"
 	info "Downloading macOS toolchain"
@@ -69,13 +62,19 @@ else
 	mac_toolchain="mac"
 fi
 
-file_name_linux="swift-${swift_version}-RELEASE-${linux_version}"
+# No Swift OS Arch builds, so use Debian base
+if [[ ${linux_version} == "arch"* ]]; then
+	target_version="${linux_version/arch/ubuntu20.04}"
+else
+	target_version="${linux_version}"
+fi
 
-dl "toolchain-${linux_version}-${swift_version}.tar.gz" "https://swift.org/builds/swift-${swift_version}-release/${linux_version/./}/swift-${swift_version}-RELEASE/${file_name_linux}.tar.gz"
+file_name_linux="swift-${swift_version}-RELEASE-${target_version}"
+dl "toolchain-${target_version}-${swift_version}.tar.gz" "https://swift.org/builds/swift-${swift_version}-release/${target_version/./}/swift-${swift_version}-RELEASE/${file_name_linux}.tar.gz"
 
 info "Unpacking Linux toolchain"
 rm -rf linux
-tar -xvf "toolchain-${linux_version}-${swift_version}.tar.gz"
+tar -xvf "toolchain-${target_version}-${swift_version}.tar.gz"
 mv "${file_name_linux}" linux
 mv linux/{usr,host}
 
@@ -114,24 +113,13 @@ rm linux/iphone/lib/swift/clang
 cp -a linux/{host,iphone}/lib/swift/clang
 # remove borked plutil in favor of plistutil
 rm linux/iphone/bin/plutil
-# remove c++ headers as included in SDK
-rm -rf linux/iphone/include/c++/
+# remove c++ headers as included in SDK [TBD]
+# rm -rf linux/iphone/include/c++/
 
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C
-if [[ "${linux_version}" == *"ubuntu"* ]]; then
-	dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz"
-	tar -xvf "darwin-tools-${linux_version}.tar.gz"
-# If distro isn't debian-based, use ubuntu20.04 as darwintools base
-else
-	if [[ "${linux_version}" =~ "aarch64" ]]; then
-		dl "darwin-tools-ubuntu20.04-aarch64.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-ubuntu20.04-aarch64.tar.gz"
-		tar -xvf "darwin-tools-ubuntu20.04-aarch64.tar.gz"
-	else
-		dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-ubuntu20.04.tar.gz"
-		tar -xvf "darwin-tools-ubuntu20.04.tar.gz"
-	fi
-fi
+dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz"
+tar -xvf "darwin-tools-${linux_version}.tar.gz"
 
 info "Packaging toolchain"
 mkdir -p ../packages

--- a/create-toolchain
+++ b/create-toolchain
@@ -24,7 +24,7 @@ err() {
 	exit 1
 }
 
-supported_plats=("ubuntu20.04" "ubuntu20.04-aarch64" "ubuntu22.04" "ubuntu22.04-aarch64" "ubi9" "ubi9-aarch64" "arch" "arch-aarch64")
+supported_plats=("ubuntu20.04" "ubuntu22.04" "ubuntu24.04" "fedora39" "archlinux")
 if ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "$1" > /dev/null; then
    	err "$1 is not a valid configuration"
 fi

--- a/create-toolchain
+++ b/create-toolchain
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")"
 
-DARWIN_TOOLS_VERSION="2.2.1"
+DARWIN_TOOLS_VERSION="3.0.0"
 
 [[ "$(uname -s)" = "Darwin" ]] && is_mac=true
 

--- a/create-toolchain
+++ b/create-toolchain
@@ -21,6 +21,12 @@ err() {
 	exit 1
 }
 
+supported_plats=("ubuntu20.04" "ubuntu20.04-aarch64" "ubuntu22.04" "ubuntu22.04-aarch64" "ubi9")
+if ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "${1}" > /dev/null && \
+   ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "${2}" > /dev/null; then
+   	err "${1} ${2} is not a valid configuration"
+fi
+
 mkdir -p toolchains
 rm -rf toolchains/*.tmp
 

--- a/create-toolchain
+++ b/create-toolchain
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")"
 
-# DARWIN_TOOLS_VERSION="2.2.1"
+DARWIN_TOOLS_VERSION="2.2.1"
 
 [[ "$(uname -s)" = "Darwin" ]] && is_mac=true
 
@@ -122,14 +122,14 @@ info "Installing Darwin tools"
 # If distro isn't debian-based, use ubuntu20.04 as darwintools base
 if ! [[ "${linux_version}" == *"ubuntu"* ]]; then
 	if [[ "${linux_version}" =~ "aarch64" ]]; then
-		dl "darwin-tools-ubuntu20.04-aarch64.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-ubuntu20.04-aarch64.tar.gz"
+		dl "darwin-tools-ubuntu20.04-aarch64.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-ubuntu20.04-aarch64.tar.gz"
 		tar -xvf "darwin-tools-ubuntu20.04-aarch64.tar.gz"
 	else
-		dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-ubuntu20.04.tar.gz"
+		dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-ubuntu20.04.tar.gz"
 		tar -xvf "darwin-tools-ubuntu20.04.tar.gz"
 	fi
 else
-	dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-${linux_version}.tar.gz"
+	dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz"
 	tar -xvf "darwin-tools-${linux_version}.tar.gz"
 fi
 

--- a/create-toolchain
+++ b/create-toolchain
@@ -69,7 +69,7 @@ dl "toolchain-${linux_version}-${swift_version}.tar.gz" "https://swift.org/build
 
 info "Unpacking Linux toolchain"
 rm -rf linux
-tar -xzvf "toolchain-${linux_version}-${swift_version}.tar.gz"
+tar -xvf "toolchain-${linux_version}-${swift_version}.tar.gz"
 mv "${file_name_linux}" linux
 mv linux/{usr,host}
 
@@ -110,7 +110,7 @@ cp -a linux/{host,iphone}/lib/swift/clang
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C
 dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-${linux_version}.tar.gz"
-tar -xzvf "darwin-tools-${linux_version}.tar.gz"
+tar -xvf "darwin-tools-${linux_version}.tar.gz"
 
 info "Packaging toolchain"
 mkdir -p ../packages

--- a/create-toolchain
+++ b/create-toolchain
@@ -114,7 +114,7 @@ rm -rf linux/iphone/include/c++/
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C
 # If distro isn't debian-based, use ubuntu20.04 as darwintools base
-if ! [[ "${linux_version}" == *"$ubuntu"* ]]; then
+if ! [[ "${linux_version}" == *"ubuntu"* ]]; then
 	dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-ubuntu20.04.tar.gz"
 	tar -xvf "darwin-tools-ubuntu20.04.tar.gz"
 else

--- a/create-toolchain
+++ b/create-toolchain
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")"
 
-DARWIN_TOOLS_VERSION="2.2.1"
+# DARWIN_TOOLS_VERSION="2.2.1"
 
 [[ "$(uname -s)" = "Darwin" ]] && is_mac=true
 
@@ -109,7 +109,7 @@ cp -a linux/{host,iphone}/lib/swift/clang
 
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C
-dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz"
+dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-${linux_version}.tar.gz"
 tar -xzvf "darwin-tools-${linux_version}.tar.gz"
 
 info "Packaging toolchain"

--- a/create-toolchain
+++ b/create-toolchain
@@ -21,7 +21,7 @@ err() {
 	exit 1
 }
 
-supported_plats=("ubuntu20.04" "ubuntu20.04-aarch64" "ubuntu22.04" "ubuntu22.04-aarch64" "ubi9")
+supported_plats=("ubuntu20.04" "ubuntu20.04-aarch64" "ubuntu22.04" "ubuntu22.04-aarch64" "ubi9" "ubi9-aarch64")
 if ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "${1}" > /dev/null && \
    ! printf '%s\0' "${supported_plats[@]}" | grep -F -x -z -- "${2}" > /dev/null; then
    	err "${1} ${2} is not a valid configuration"
@@ -121,8 +121,13 @@ info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C
 # If distro isn't debian-based, use ubuntu20.04 as darwintools base
 if ! [[ "${linux_version}" == *"ubuntu"* ]]; then
-	dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-ubuntu20.04.tar.gz"
-	tar -xvf "darwin-tools-ubuntu20.04.tar.gz"
+	if [[ "${linux_version}" =~ "aarch64" ]]; then
+		dl "darwin-tools-ubuntu20.04-aarch64.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-ubuntu20.04-aarch64.tar.gz"
+		tar -xvf "darwin-tools-ubuntu20.04-aarch64.tar.gz"
+	else
+		dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-ubuntu20.04.tar.gz"
+		tar -xvf "darwin-tools-ubuntu20.04.tar.gz"
+	fi
 else
 	dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-${linux_version}.tar.gz"
 	tar -xvf "darwin-tools-${linux_version}.tar.gz"

--- a/create-toolchain
+++ b/create-toolchain
@@ -106,6 +106,8 @@ cp -a "${mac_toolchain}"/usr/include linux/iphone/include
 # ...but-but replace the mac lib/swift/clang symlink with the linux one
 rm linux/iphone/lib/swift/clang
 cp -a linux/{host,iphone}/lib/swift/clang
+# remove c++ headers as included with SDK
+rm -rf linux/iphone/include/c++/
 
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C

--- a/create-toolchain
+++ b/create-toolchain
@@ -113,8 +113,14 @@ rm -rf linux/iphone/include/c++/
 
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C
-dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-${linux_version}.tar.gz"
-tar -xvf "darwin-tools-${linux_version}.tar.gz"
+# If distro isn't debian-based, use ubuntu20.04 as darwintools base
+if ! [[ "${linux_version}" == *"$ubuntu"* ]]; then
+	dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-ubuntu20.04.tar.gz"
+	tar -xvf "darwin-tools-ubuntu20.04.tar.gz"
+else
+	dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/l1ghtmann/darwin-tools-linux/releases/latest/download/darwin-tools-${linux_version}.tar.gz"
+	tar -xvf "darwin-tools-${linux_version}.tar.gz"
+fi
 
 info "Packaging toolchain"
 mkdir -p ../packages

--- a/create-toolchain
+++ b/create-toolchain
@@ -119,8 +119,11 @@ rm -rf linux/iphone/include/c++/
 
 info "Installing Darwin tools"
 # The hierarchy lines up with ours just right so we dont need to -C
+if [[ "${linux_version}" == *"ubuntu"* ]]; then
+	dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz"
+	tar -xvf "darwin-tools-${linux_version}.tar.gz"
 # If distro isn't debian-based, use ubuntu20.04 as darwintools base
-if ! [[ "${linux_version}" == *"ubuntu"* ]]; then
+else
 	if [[ "${linux_version}" =~ "aarch64" ]]; then
 		dl "darwin-tools-ubuntu20.04-aarch64.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-ubuntu20.04-aarch64.tar.gz"
 		tar -xvf "darwin-tools-ubuntu20.04-aarch64.tar.gz"
@@ -128,9 +131,6 @@ if ! [[ "${linux_version}" == *"ubuntu"* ]]; then
 		dl "darwin-tools-ubuntu20.04.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-ubuntu20.04.tar.gz"
 		tar -xvf "darwin-tools-ubuntu20.04.tar.gz"
 	fi
-else
-	dl "darwin-tools-${linux_version}.tar.gz" "https://github.com/kabiroberai/darwin-tools-linux/releases/download/v${DARWIN_TOOLS_VERSION}/darwin-tools-${linux_version}.tar.gz"
-	tar -xvf "darwin-tools-${linux_version}.tar.gz"
 fi
 
 info "Packaging toolchain"

--- a/create-toolchain
+++ b/create-toolchain
@@ -106,7 +106,9 @@ cp -a "${mac_toolchain}"/usr/include linux/iphone/include
 # ...but-but replace the mac lib/swift/clang symlink with the linux one
 rm linux/iphone/lib/swift/clang
 cp -a linux/{host,iphone}/lib/swift/clang
-# remove c++ headers as included with SDK
+# remove borked plutil in favor of plistutil
+rm linux/iphone/bin/plutil
+# remove c++ headers as included in SDK
 rm -rf linux/iphone/include/c++/
 
 info "Installing Darwin tools"


### PR DESCRIPTION
Resolves #6 and resolves #7

Changes
- Updates workflow
- Adds aarch64, RHEL, and Arch builds
- Adds logic to confirm linux_version is one of the supported versions
- Removes borked plutil

Tested successfully [here](https://github.com/L1ghtmann/swift-toolchain-linux/actions/runs/9341624422)
- AArch64 builds failed as they are absent from my DT release currently (see the [separate DT pr](https://github.com/kabiroberai/darwin-tools-linux/pull/7)) 